### PR TITLE
Variable geometry

### DIFF
--- a/export_openscad.py
+++ b/export_openscad.py
@@ -112,7 +112,8 @@ def write_file(filepath, objects, scene,
 """)
 
     fw("""//
-//  Note: If your mesh is non-manifold and/or OpenSCAD complains about the simple "polyhedron" variation,
+//  Note 1: Switch to "View - Thrown Together (F12)" and look for purple-showing facets to debug incomplete mesh polyhedron issues.
+//  Note 2: If your mesh is non-manifold and/or OpenSCAD complains about the simple "polyhedron" variation,
 //    try using the "frame" or "shell" variants.
 """)
 


### PR DESCRIPTION
Hi Peter,

I took your code as a starting point and reworked the resulting OpenSCAD output into a set of functions, modules and example test structures.
- Writing out the triangles and points as functions (versus variables or modules) makes it easy to "use" them in other files while leaving room to parameterize them at a future date.
- Functions and modules are named according to the output file name + Blender object name to keep them reasonably unique but easily cross-referenced when building and using them as library elements.
- Modules are generated as basic starting points for using the function-geometry directly for polyhedrons and to provide some of examples of how the points can be iterated over in OpenSCAD to create new objects.

There's probably tons of room for optimizing the Blender and Python aspects of the code;  OpenSCAD is what I'm most familiar with.  If this is going in a completely different direction from what you have in mind, that's ok too. I don't mind forking it to a different name to keep your code-base clean.

Andrew.
